### PR TITLE
ci(publish): set provenance to false for docker/build-push-action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+          provenance: false
           push: true
           tags: |
             coatldev/devpi:${{ needs.tagger.outputs.version }}


### PR DESCRIPTION
when provenance is set to true, it creates additional artifacts in ghcr and quay
